### PR TITLE
Update retrieve_subscriptions for ended status to return both canceled and expired subscriptions

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -186,7 +186,7 @@ module StripeMock
         when "all"
           # Include all subscriptions
         when 'ended'
-          subs = subs.filter { |subscription| subscription[:status] == "canceled" || subscription[:status] == 'incomplete_expired' }
+          subs = subs.filter { |subscription| %w[canceled incomplete_expired].include?(subscription[:status]) }
         else
           subs = subs.filter {|subscription| subscription[:status] == params[:status]}
         end

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -185,6 +185,8 @@ module StripeMock
           subs = subs.filter {|subscription| subscription[:status] != "canceled"}
         when "all"
           # Include all subscriptions
+        when 'ended'
+          subs = subs.filter { |subscription| subscription[:status] == "canceled" || subscription[:status] == 'incomplete_expired' }
         else
           subs = subs.filter {|subscription| subscription[:status] == params[:status]}
         end


### PR DESCRIPTION
Stripe API sends the subscriptions with the `'canceled'` status when we pass status as `ended`

As per the Stripe API docs - [here](https://stripe.com/docs/api/subscriptions/list#list_subscriptions-status), `ended` status must return the `canceled` and `subscriptions expired due to incomplete payment` which I believe is the `incomplete_expired` status.
>Pass ended to find subscriptions that are canceled and subscriptions that are expired due to [incomplete payment](https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses).

As we can see from the Rails console code, we get all canceled subscriptions on passing `ended` to the API.
```ruby
3.1.4 :002 > Stripe::Subscription.list(customer: 'cus_O08snPcbsKOVjV', status: 'ended').map(&:status)
 => ["canceled", "canceled", "canceled", "canceled"]
```

But the same is not reflected in the stripe ruby mocks. They have not handled the `ended` scenario for listing subscriptions. The above code returns nil/empty in tests.

So this PR adds the ability for the subscription list API in Ruby mocks to return the `canceled/incomplete_expired` subscriptions.

This change will only affect the PR - https://github.com/marlytics/ll-app/pull/2217