### PR TITLE
Add support to list prices by passing a product id

### DIFF
--- a/lib/stripe_mock/request_handlers/prices.rb
+++ b/lib/stripe_mock/request_handlers/prices.rb
@@ -43,6 +43,10 @@ module StripeMock
         price_data = prices.values
         validate_list_prices_params(params)
 
+        if params[:product]
+          price_data.select! { |price| price[:product] == params[:product] }
+        end
+
         if params.key?(:lookup_keys)
           price_data.select! do |price|
             params[:lookup_keys].include?(price[:lookup_key])


### PR DESCRIPTION
This PR adds support to list prices by their product:
https://stripe.com/docs/api/prices/list#list_prices-product

```
Stripe::Price.list(product: 'prod_xxx')
```