### PR TITLE
Add invoice number to invoices mock

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -413,6 +413,7 @@ module StripeMock
         id: 'in_test_invoice',
         status: 'open',
         invoice_pdf: 'pdf_url',
+        number: 'number',
         hosted_invoice_url: 'hosted_invoice_url',
         created: 1349738950,
         period_end: 1349738950,


### PR DESCRIPTION
The fetch invoices api response have "number" attribute which contains the invoice number https://stripe.com/docs/api/invoices/retrieve

Adding the same in ruby mock as well