### PR TITLE
Allow user to fetch invoices based on status params

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -35,6 +35,8 @@ module StripeMock
           result.delete_if { |k,v| v[:customer] != params[:customer] }
         end
 
+        result.delete_if { |_k, v| v[:status] != params[:status] } if params[:status]
+
         Data.mock_list_object(result.values, params)
       end
 


### PR DESCRIPTION
We have stripe api [Stripe::Invoice.list](https://docs.stripe.com/api/invoices/list). You can list all invoices

We can also pass status param to this api to fetch specific invoices. The status of the invoice can be, one of draft, open, paid, uncollectible, or void.

This status filter was not present in the stripe-ruby-mock gem, passing specific status would still return all the invoices. This PR resolves the issue and fixes that