### PR TITLE
Raise error for upcoming invoice when subscription set to cancel

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -54,6 +54,8 @@ module StripeMock
           params.merge!(cancel_at_period_end: true, canceled_at: now, cancel_at: params[:current_period_end])
         elsif options[:cancel_at_period_end] == false
           params.merge!(cancel_at_period_end: false, canceled_at: nil)
+        elsif options[:cancel_at].present?
+          params.merge!(cancel_at_period_end: false, canceled_at: now, cancel_at: options[:cancel_at])
         end
 
         params

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -86,6 +86,10 @@ module StripeMock
           raise Stripe::InvalidRequestError.new('Cannot specify proration date outside of current subscription period', nil, http_status: 400)
         end
 
+        if params[:subscription_items].blank? && subscription[:cancel_at].present? && subscription[:cancel_at] <= subscription[:current_period_end]
+          raise Stripe::InvalidRequestError.new("No upcoming invoices for customer: #{customer[:id]}", nil, http_status: 404)
+        end
+
         prorating = false
         subscription_proration_date = nil
         subscription_plan_id = params[:subscription_plan] || subscription[:plan][:id]


### PR DESCRIPTION
Allow subscription to set future cancellation date and also add support for future invoice