### PR TITLE
Add Support for Expanding charge Object in Stripe::Invoice Mock Responses

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -221,7 +221,7 @@ module StripeMock
         },
         receipt_email: nil,
         receipt_number: nil,
-        receipt_url: nil,
+        receipt_url: 'receipt_url',
         refunded: false,
         shipping: {},
         statement_descriptor: "Charge #{charge_id}",

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -46,6 +46,15 @@ module StripeMock
 
         result.delete_if { |_k, v| v[:status] != params[:status] } if params[:status]
 
+        if params[:expand].is_a?(Array) && params[:expand].any? { |data| data.match?(/data.charge/) }
+          result.values.each do |invoice|
+            next if invoice[:charge].nil?
+
+            invoice[:charge] = charges[invoice[:charge]].dup
+          end
+          params.delete(:expand)
+        end
+
         Data.mock_list_object(result.values, params)
       end
 


### PR DESCRIPTION
This PR introduces changes to the stripe-ruby-mock gem to support expanding the charge object when retrieving or listing Stripe::Invoice objects. This is particularly useful for testing scenarios where paid invoices need to include the associated charge object with its properties, such as receipt_url.