### PR TITLE
Add Support for trial_settings on Stripe::Subscription Mock Responses

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -416,6 +416,11 @@ module StripeMock
         end_at: nil,
         pause_collection: nil,
         cancellation_details: {},
+        trial_settings: {
+          end_behavior: {
+            missing_payment_method: 'create_invoice'
+          }
+        },
       }, params)
     end
 

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -37,7 +37,7 @@ module StripeMock
         start_time = options[:current_period_start] || now
         params = { customer: cus[:id], current_period_start: start_time, created: created_time }
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
-        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates|pending_invoice_item_interval|default_payment_method|collection_method|automatic_tax|cancellation_details/
+        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates|pending_invoice_item_interval|default_payment_method|collection_method|automatic_tax|cancellation_details|trial_settings/
         params.merge! options.select {|k,v| k =~ keys_to_merge}
 
         # TODO: Implement coupon logic


### PR DESCRIPTION
## Add support for trial_settings on subscriptions

Adds support for the `trial_settings` attribute on subscriptions in stripe-ruby-mock.

### Connected PR
 - https://github.com/marlytics/ll-ai-core/pull/813

### Changes
- **lib/stripe_mock/data.rb** — `mock_subscription` now returns a default `trial_settings` block (alongside `cancellation_details`), defaulting `end_behavior.missing_payment_method` to Stripe's real default, `create_invoice`.
- **lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb** — added `trial_settings` to the `keys_to_merge` regex so a value passed to `Subscription.create` is persisted onto the subscription.
- **lib/stripe_mock/request_handlers/subscriptions.rb** — `trial_settings` was already present in `allowed_params`, so no change was needed.

### Why
This lets consumers rely on `subscription.trial_settings.end_behavior.missing_payment_method` against mocked subscriptions (e.g. for a `trial_ends_in_cancellation` helper).
